### PR TITLE
feat: handle missing firebase bucket

### DIFF
--- a/src/app/api/gdpr/delete-thread/route.ts
+++ b/src/app/api/gdpr/delete-thread/route.ts
@@ -15,8 +15,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   batch.delete(tRef);
   await batch.commit();
 
-  const [files] = await bucket.getFiles({ prefix: `orgs/${orgId}/threads/${id}/` });
-  await Promise.all(files.map(f => f.delete()));
+  if (bucket) {
+    const [files] = await bucket.getFiles({ prefix: `orgs/${orgId}/threads/${id}/` });
+    await Promise.all(files.map(f => f.delete()));
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -9,12 +9,13 @@ if (!global.__FIREBASE_ADMIN__) {
   const projectId = process.env.FIREBASE_PROJECT_ID;
   const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
   const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  const storageBucket = process.env.FIREBASE_STORAGE_BUCKET;
 
   admin.initializeApp(
     projectId && clientEmail && privateKey
       ? {
           credential: admin.credential.cert({ projectId, clientEmail, privateKey }),
-          storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+          ...(storageBucket && { storageBucket }),
         }
       : {}
   );
@@ -23,5 +24,7 @@ if (!global.__FIREBASE_ADMIN__) {
 
 export const adminApp = global.__FIREBASE_ADMIN__!;
 export const db = admin.firestore();
-export const bucket = admin.storage().bucket();
+export const bucket = process.env.FIREBASE_STORAGE_BUCKET
+  ? admin.storage().bucket(process.env.FIREBASE_STORAGE_BUCKET)
+  : null;
 export const auth = admin.auth();


### PR DESCRIPTION
## Summary
- avoid initializing storage bucket when FIREBASE_STORAGE_BUCKET is undefined
- guard GDPR delete-thread API against missing storage bucket

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1c2f683208332bda3ef9900fa18c7