### PR TITLE
Avoid importing Prisma when not needed

### DIFF
--- a/src/lib/repo/index.ts
+++ b/src/lib/repo/index.ts
@@ -1,6 +1,12 @@
-import { firebaseRepo } from "./firestore";
-import { prismaRepo } from "./prisma";
 import type { Repo } from "./contracts";
 
-export const repo: Repo =
-  process.env.DATA_BACKEND === "prisma" ? prismaRepo : firebaseRepo;
+let selected: Repo;
+if (process.env.DATA_BACKEND === "prisma") {
+  const { prismaRepo } = await import("./prisma");
+  selected = prismaRepo;
+} else {
+  const { firebaseRepo } = await import("./firestore");
+  selected = firebaseRepo;
+}
+
+export const repo: Repo = selected;


### PR DESCRIPTION
## Summary
- Load chosen data backend dynamically to prevent unnecessary imports

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b4b00e8454833298ef7408a0a452c9